### PR TITLE
Introduce provider-based state

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import 'pages/workout_home_page.dart';
+import 'providers/workout_data.dart';
 
 void main() {
-  runApp(WorkoutApp());
+  runApp(const WorkoutApp());
 }
 
 class WorkoutApp extends StatelessWidget {
+  const WorkoutApp({super.key});
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: '운동 기록',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
+    return ChangeNotifierProvider(
+      create: (_) => WorkoutData(),
+      child: MaterialApp(
+        title: '운동 기록',
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+          visualDensity: VisualDensity.adaptivePlatformDensity,
+        ),
+        home: const WorkoutHomePage(),
       ),
-      home: WorkoutHomePage(),
     );
   }
 }

--- a/lib/pages/workout_home_page.dart
+++ b/lib/pages/workout_home_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 import '../models/workout.dart';
 import '../widgets/body_painter.dart';
+import '../providers/workout_data.dart';
 
 class WorkoutHomePage extends StatefulWidget {
   @override
@@ -14,25 +16,6 @@ class _WorkoutHomePageState extends State<WorkoutHomePage> {
   DateTime _focusedDay = DateTime.now();
   DateTime? _selectedDay;
 
-  // 예시 운동 데이터
-  Map<DateTime, List<WorkoutRecord>> _workoutData = {
-    DateTime.now(): [
-      WorkoutRecord('벤치프레스', '3세트', '80kg x 10회', MuscleGroup.chest, 8),
-      WorkoutRecord('스쿼트', '4세트', '100kg x 8회', MuscleGroup.legs, 9),
-      WorkoutRecord('데드리프트', '3세트', '120kg x 5회', MuscleGroup.back, 9),
-    ],
-    DateTime.now().subtract(Duration(days: 1)): [
-      WorkoutRecord('풀업', '3세트', '체중 x 12회', MuscleGroup.back, 7),
-      WorkoutRecord('딥스', '3세트', '체중 x 15회', MuscleGroup.chest, 6),
-      WorkoutRecord('어깨 프레스', '4세트', '40kg x 12회', MuscleGroup.shoulders, 8),
-    ],
-    DateTime.now().subtract(Duration(days: 2)): [
-      WorkoutRecord('바이셉 컬', '3세트', '15kg x 15회', MuscleGroup.arms, 6),
-      WorkoutRecord('트라이셉 딥', '3세트', '체중 x 12회', MuscleGroup.arms, 7),
-      WorkoutRecord('레그 프레스', '4세트', '150kg x 12회', MuscleGroup.legs, 8),
-    ],
-  };
-
   @override
   void initState() {
     super.initState();
@@ -40,7 +23,8 @@ class _WorkoutHomePageState extends State<WorkoutHomePage> {
   }
 
   List<WorkoutRecord> _getWorkoutsForDay(DateTime day) {
-    return _workoutData[DateTime(day.year, day.month, day.day)] ?? [];
+    final provider = Provider.of<WorkoutData>(context, listen: false);
+    return provider.workoutsForDay(day);
   }
 
   Map<MuscleGroup, MuscleRecoveryInfo> _getMuscleRecoveryStatus() {
@@ -403,7 +387,8 @@ class _WorkoutHomePageState extends State<WorkoutHomePage> {
   }
 
   Widget _buildWorkoutList() {
-    final workouts = _getWorkoutsForDay(_selectedDay ?? DateTime.now());
+    final provider = Provider.of<WorkoutData>(context);
+    final workouts = provider.workoutsForDay(_selectedDay ?? DateTime.now());
 
     if (workouts.isEmpty) {
       return Container(
@@ -601,14 +586,11 @@ class _WorkoutHomePageState extends State<WorkoutHomePage> {
       _selectedDay!.day,
     );
 
-    setState(() {
-      if (_workoutData[selectedDate] == null) {
-        _workoutData[selectedDate] = [];
-      }
-      _workoutData[selectedDate]!.add(
-        WorkoutRecord(exercise, sets, details, muscle, intensity),
-      );
-    });
+    final provider = Provider.of<WorkoutData>(context, listen: false);
+    provider.addWorkout(
+      selectedDate,
+      WorkoutRecord(exercise, sets, details, muscle, intensity),
+    );
   }
 
   void _deleteWorkout(int index) {
@@ -618,8 +600,7 @@ class _WorkoutHomePageState extends State<WorkoutHomePage> {
       _selectedDay!.day,
     );
 
-    setState(() {
-      _workoutData[selectedDate]?.removeAt(index);
-    });
+    final provider = Provider.of<WorkoutData>(context, listen: false);
+    provider.deleteWorkout(selectedDate, index);
   }
 }

--- a/lib/providers/workout_data.dart
+++ b/lib/providers/workout_data.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import '../models/workout.dart';
+
+class WorkoutData extends ChangeNotifier {
+  final Map<DateTime, List<WorkoutRecord>> _workoutData = {
+    DateTime.now(): [
+      WorkoutRecord('벤치프레스', '3세트', '80kg x 10회', MuscleGroup.chest, 8),
+      WorkoutRecord('스쿼트', '4세트', '100kg x 8회', MuscleGroup.legs, 9),
+      WorkoutRecord('데드리프트', '3세트', '120kg x 5회', MuscleGroup.back, 9),
+    ],
+    DateTime.now().subtract(Duration(days: 1)): [
+      WorkoutRecord('풀업', '3세트', '체중 x 12회', MuscleGroup.back, 7),
+      WorkoutRecord('딥스', '3세트', '체중 x 15회', MuscleGroup.chest, 6),
+      WorkoutRecord('어깨 프레스', '4세트', '40kg x 12회', MuscleGroup.shoulders, 8),
+    ],
+    DateTime.now().subtract(Duration(days: 2)): [
+      WorkoutRecord('바이셉 컬', '3세트', '15kg x 15회', MuscleGroup.arms, 6),
+      WorkoutRecord('트라이셉 딥', '3세트', '체중 x 12회', MuscleGroup.arms, 7),
+      WorkoutRecord('레그 프레스', '4세트', '150kg x 12회', MuscleGroup.legs, 8),
+    ],
+  };
+
+  List<WorkoutRecord> workoutsForDay(DateTime day) {
+    final key = DateTime(day.year, day.month, day.day);
+    return _workoutData[key] ?? [];
+  }
+
+  void addWorkout(DateTime day, WorkoutRecord record) {
+    final key = DateTime(day.year, day.month, day.day);
+    if (_workoutData[key] == null) {
+      _workoutData[key] = [];
+    }
+    _workoutData[key]!.add(record);
+    notifyListeners();
+  }
+
+  void deleteWorkout(DateTime day, int index) {
+    final key = DateTime(day.year, day.month, day.day);
+    _workoutData[key]?.removeAt(index);
+    notifyListeners();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   table_calendar: ^3.2.0
+  provider: ^6.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `provider` package
- manage workout data with `WorkoutData` provider
- wrap `WorkoutApp` with `ChangeNotifierProvider`
- update workout page to use provider-based state

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc094160083278ab7636ae83b2349