### PR TITLE
Add settings page with dark mode toggle

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'pages/workout_home_page.dart';
 import 'providers/workout_data.dart';
+import 'providers/theme_provider.dart';
 
 void main() {
   runApp(const WorkoutApp());
@@ -13,15 +14,24 @@ class WorkoutApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => WorkoutData(),
-      child: MaterialApp(
-        title: '운동 기록',
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-          visualDensity: VisualDensity.adaptivePlatformDensity,
-        ),
-        home: WorkoutHomePage(),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => WorkoutData()),
+        ChangeNotifierProvider(create: (_) => ThemeProvider()),
+      ],
+      child: Consumer<ThemeProvider>(
+        builder: (context, themeProvider, _) {
+          return MaterialApp(
+            title: '운동 기록',
+            theme: ThemeData(
+              primarySwatch: Colors.blue,
+              visualDensity: VisualDensity.adaptivePlatformDensity,
+            ),
+            darkTheme: ThemeData.dark(),
+            themeMode: themeProvider.themeMode,
+            home: WorkoutHomePage(),
+          );
+        },
       ),
     );
   }

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/theme_provider.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('설정'),
+      ),
+      body: Consumer<ThemeProvider>(
+        builder: (context, themeProvider, child) {
+          return ListView(
+            children: [
+              SwitchListTile(
+                title: const Text('다크 모드'),
+                value: themeProvider.isDarkMode,
+                onChanged: (value) {
+                  themeProvider.toggleTheme(value);
+                },
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/workout_home_page.dart
+++ b/lib/pages/workout_home_page.dart
@@ -5,6 +5,7 @@ import 'package:table_calendar/table_calendar.dart';
 import '../models/workout.dart';
 import '../widgets/body_painter.dart';
 import '../providers/workout_data.dart';
+import 'settings_page.dart';
 
 class WorkoutHomePage extends StatefulWidget {
   @override
@@ -67,6 +68,16 @@ class _WorkoutHomePageState extends State<WorkoutHomePage> {
         title: Text('운동 기록'),
         backgroundColor: Colors.blue[600],
         elevation: 0,
+        actions: [
+          IconButton(
+            icon: Icon(Icons.settings),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const SettingsPage()),
+              );
+            },
+          ),
+        ],
       ),
       body: CustomScrollView(
         slivers: [

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  static const String _themeKey = 'themeMode';
+  ThemeMode _themeMode = ThemeMode.light;
+
+  ThemeProvider() {
+    _loadTheme();
+  }
+
+  ThemeMode get themeMode => _themeMode;
+  bool get isDarkMode => _themeMode == ThemeMode.dark;
+
+  void toggleTheme(bool isOn) {
+    _themeMode = isOn ? ThemeMode.dark : ThemeMode.light;
+    notifyListeners();
+    _saveTheme();
+  }
+
+  Future<void> _loadTheme() async {
+    final prefs = await SharedPreferences.getInstance();
+    final isDark = prefs.getBool(_themeKey) ?? false;
+    _themeMode = isDark ? ThemeMode.dark : ThemeMode.light;
+    notifyListeners();
+  }
+
+  Future<void> _saveTheme() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_themeKey, isDarkMode);
+  }
+}


### PR DESCRIPTION
## Summary
- implement a `ThemeProvider` to manage dark mode setting
- add a settings page with a switch for dark mode
- show settings icon in the app bar
- wire theme provider into main app

## Testing
- `flutter test` *(fails: `flutter` not found)*
- `dart format lib test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bced477b4832781595b6ee5473271