### PR TITLE
Centralize design theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'pages/workout_home_page.dart';
 import 'providers/workout_data.dart';
 import 'providers/theme_provider.dart';
+import 'theme/app_theme.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -24,11 +25,8 @@ class WorkoutApp extends StatelessWidget {
         builder: (context, themeProvider, _) {
           return MaterialApp(
             title: '운동 기록',
-            theme: ThemeData(
-              primarySwatch: Colors.blue,
-              visualDensity: VisualDensity.adaptivePlatformDensity,
-            ),
-            darkTheme: ThemeData.dark(),
+            theme: AppTheme.lightTheme,
+            darkTheme: AppTheme.darkTheme,
             themeMode: themeProvider.themeMode,
             home: WorkoutHomePage(),
           );

--- a/lib/pages/workout_home_page.dart
+++ b/lib/pages/workout_home_page.dart
@@ -11,7 +11,7 @@ import '../providers/workout_data.dart';
 import 'package:provider/provider.dart';
 
 class WorkoutHomePage extends StatefulWidget {
-  const WorkoutHomePage({Key? key}) : super(key: key);
+  const WorkoutHomePage({super.key});
 
   @override
   WorkoutHomePageState createState() => WorkoutHomePageState();
@@ -97,7 +97,7 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _showAddWorkoutDialog,
-        backgroundColor: Colors.blue[600],
+        backgroundColor: Theme.of(context).colorScheme.primary,
         child: const Icon(Icons.add),
       ),
     );
@@ -196,7 +196,7 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
                   },
 
                   style:
-                      ElevatedButton.styleFrom(backgroundColor: Colors.blue[600]),
+                      ElevatedButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.primary),
 
                   child: const Text('추가'),
                 ),

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  static const Color primary = Color(0xFF2196F3); // blue
+  static const Color secondary = Color(0xFFFF9800); // orange
+  static const Color hint = Colors.grey;
+}
+
+class AppTextStyles {
+  static const TextStyle sectionTitle = TextStyle(
+    fontSize: 20,
+    fontWeight: FontWeight.bold,
+  );
+}
+
+class AppTheme {
+  static ThemeData get lightTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.primary,
+          primary: AppColors.primary,
+          secondary: AppColors.secondary,
+          brightness: Brightness.light,
+        ),
+        textTheme: const TextTheme(
+          titleLarge: AppTextStyles.sectionTitle,
+        ),
+        useMaterial3: true,
+      );
+
+  static ThemeData get darkTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.primary,
+          primary: AppColors.primary,
+          secondary: AppColors.secondary,
+          brightness: Brightness.dark,
+        ),
+        textTheme: const TextTheme(
+          titleLarge: AppTextStyles.sectionTitle,
+        ),
+        useMaterial3: true,
+      );
+}

--- a/lib/widgets/home_sections/calendar_section.dart
+++ b/lib/widgets/home_sections/calendar_section.dart
@@ -32,7 +32,9 @@ class CalendarSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
-      color: isDark ? Colors.grey[850] : Colors.blue[50],
+      color: isDark
+          ? Colors.grey[850]
+          : Theme.of(context).colorScheme.primary.withOpacity(0.1),
       padding: const EdgeInsets.all(16),
       child: Card(
         elevation: 4,
@@ -47,16 +49,17 @@ class CalendarSection extends StatelessWidget {
             startingDayOfWeek: StartingDayOfWeek.monday,
             calendarStyle: CalendarStyle(
               outsideDaysVisible: false,
-              markerDecoration: const BoxDecoration(
-                color: Colors.orange,
+              markerDecoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.secondary,
                 shape: BoxShape.circle,
               ),
               selectedDecoration: BoxDecoration(
-                color: Colors.blue[600],
+                color: Theme.of(context).colorScheme.primary,
                 shape: BoxShape.circle,
               ),
               todayDecoration: BoxDecoration(
-                color: Colors.blue[300],
+                color:
+                    Theme.of(context).colorScheme.primary.withOpacity(0.7),
                 shape: BoxShape.circle,
               ),
             ),
@@ -65,7 +68,7 @@ class CalendarSection extends StatelessWidget {
               titleCentered: true,
               formatButtonShowsNext: false,
               formatButtonDecoration: BoxDecoration(
-                color: Colors.blue[600],
+                color: Theme.of(context).colorScheme.primary,
                 borderRadius: BorderRadius.circular(20),
               ),
               formatButtonTextStyle: const TextStyle(color: Colors.white),

--- a/lib/widgets/home_sections/muscle_recovery_section.dart
+++ b/lib/widgets/home_sections/muscle_recovery_section.dart
@@ -63,19 +63,16 @@ class MuscleRecoverySection extends StatelessWidget {
 
               Text(
                 '근육 회복 상태',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-
-                  color: isDark ? Colors.white : Colors.black,
-
-                ),
+                style: Theme.of(context)
+                    .textTheme
+                    .titleLarge
+                    ?.copyWith(color: isDark ? Colors.white : Colors.black),
               ),
             ],
           ),
           const SizedBox(height: 16),
 
-          _buildMuscleRecoveryView(recoveryStatus, isDark),
+          _buildMuscleRecoveryView(context, recoveryStatus, isDark),
 
         ],
       ),
@@ -83,8 +80,9 @@ class MuscleRecoverySection extends StatelessWidget {
   }
 
   Widget _buildMuscleRecoveryView(
-
-      Map<MuscleGroup, MuscleRecoveryInfo> recoveryStatus, bool isDark) {
+      BuildContext context,
+      Map<MuscleGroup, MuscleRecoveryInfo> recoveryStatus,
+      bool isDark) {
 
     return SizedBox(
       height: 400,
@@ -108,13 +106,13 @@ class MuscleRecoverySection extends StatelessWidget {
                   Text(
 
                     '회복 상태',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-
-                      color: isDark ? Colors.white : Colors.black,
-
-                    ),
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: isDark ? Colors.white : Colors.black,
+                        ),
                   ),
                   const SizedBox(height: 16),
                   Expanded(

--- a/lib/widgets/home_sections/scroll_hint_section.dart
+++ b/lib/widgets/home_sections/scroll_hint_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../theme/app_theme.dart';
 
 class ScrollHintSection extends StatelessWidget {
   const ScrollHintSection({super.key});
@@ -12,11 +13,11 @@ class ScrollHintSection extends StatelessWidget {
           Icon(
             Icons.keyboard_arrow_down,
             size: 30,
-            color: Colors.grey,
+            color: AppColors.hint,
           ),
           Text(
             '아래로 스크롤하여 운동 기록 보기',
-            style: TextStyle(color: Colors.grey, fontSize: 14),
+            style: TextStyle(color: AppColors.hint, fontSize: 14),
           ),
         ],
       ),

--- a/lib/widgets/home_sections/workout_log_section.dart
+++ b/lib/widgets/home_sections/workout_log_section.dart
@@ -26,16 +26,14 @@ class WorkoutLogSection extends StatelessWidget {
         children: [
           Row(
             children: [
-              Icon(Icons.fitness_center, color: Colors.blue[600]),
+              Icon(Icons.fitness_center,
+                  color: Theme.of(context).colorScheme.primary),
               const SizedBox(width: 8),
               Text(
                 selectedDay != null
                     ? '${selectedDay!.month}월 ${selectedDay!.day}일 운동 기록'
                     : '오늘의 운동 기록',
-                style: const TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                ),
+                style: Theme.of(context).textTheme.titleLarge,
               ),
             ],
           ),
@@ -67,7 +65,8 @@ class WorkoutLogSection extends StatelessWidget {
               ElevatedButton(
                 onPressed: onAddWorkout,
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.blue[600],
+                  backgroundColor:
+                      Theme.of(context).colorScheme.primary,
                 ),
                 child: const Text('운동 기록 추가'),
               ),
@@ -88,8 +87,10 @@ class WorkoutLogSection extends StatelessWidget {
           elevation: 2,
           child: ListTile(
             leading: CircleAvatar(
-              backgroundColor: Colors.blue[100],
-              child: Icon(Icons.fitness_center, color: Colors.blue[600]),
+              backgroundColor:
+                  Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              child: Icon(Icons.fitness_center,
+                  color: Theme.of(context).colorScheme.primary),
             ),
             title: Text(
               workout.exercise,

--- a/test/workout_test.dart
+++ b/test/workout_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutterstudy/main.dart';
 import 'package:flutterstudy/pages/workout_home_page.dart';
 import 'package:flutterstudy/models/workout.dart';


### PR DESCRIPTION
## Summary
- add `AppTheme` to define colors and text styles in one place
- use `AppTheme` and `Theme.of(context)` for common colors and fonts
- update widgets to read theme values
- fix context usage in `MuscleRecoverySection`
- clean up unused imports

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be19de1ec8327be54b778ac10555c