### PR TITLE
Centralize text colors

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'pages/workout_home_page.dart';
 import 'providers/workout_data.dart';
 import 'providers/theme_provider.dart';
+import 'theme/app_theme.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -24,11 +25,8 @@ class WorkoutApp extends StatelessWidget {
         builder: (context, themeProvider, _) {
           return MaterialApp(
             title: '운동 기록',
-            theme: ThemeData(
-              primarySwatch: Colors.blue,
-              visualDensity: VisualDensity.adaptivePlatformDensity,
-            ),
-            darkTheme: ThemeData.dark(),
+            theme: AppTheme.lightTheme,
+            darkTheme: AppTheme.darkTheme,
             themeMode: themeProvider.themeMode,
             home: WorkoutHomePage(),
           );

--- a/lib/pages/workout_home_page.dart
+++ b/lib/pages/workout_home_page.dart
@@ -11,7 +11,7 @@ import '../providers/workout_data.dart';
 import 'package:provider/provider.dart';
 
 class WorkoutHomePage extends StatefulWidget {
-  const WorkoutHomePage({Key? key}) : super(key: key);
+  const WorkoutHomePage({super.key});
 
   @override
   WorkoutHomePageState createState() => WorkoutHomePageState();
@@ -97,7 +97,7 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _showAddWorkoutDialog,
-        backgroundColor: Colors.blue[600],
+        backgroundColor: Theme.of(context).colorScheme.primary,
         child: const Icon(Icons.add),
       ),
     );
@@ -196,7 +196,7 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
                   },
 
                   style:
-                      ElevatedButton.styleFrom(backgroundColor: Colors.blue[600]),
+                      ElevatedButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.primary),
 
                   child: const Text('추가'),
                 ),

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  static const Color primary = Color(0xFF2196F3); // blue
+  static const Color secondary = Color(0xFFFF9800); // orange
+  static const Color hint = Colors.grey;
+
+  static const Color lightTextMain = Colors.black87;
+  static const Color lightTextFaded = Colors.black54;
+  static const Color darkTextMain = Colors.white;
+  static const Color darkTextFaded = Colors.white70;
+}
+
+
+class AppTheme {
+  static ThemeData get lightTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.primary,
+          primary: AppColors.primary,
+          secondary: AppColors.secondary,
+          brightness: Brightness.light,
+        ),
+        textTheme: const TextTheme(
+          titleLarge: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: AppColors.lightTextMain,
+          ),
+          bodyLarge: TextStyle(color: AppColors.lightTextMain),
+          bodyMedium: TextStyle(color: AppColors.lightTextMain),
+          bodySmall: TextStyle(color: AppColors.lightTextFaded),
+        ),
+        useMaterial3: true,
+      );
+
+  static ThemeData get darkTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.primary,
+          primary: AppColors.primary,
+          secondary: AppColors.secondary,
+          brightness: Brightness.dark,
+        ),
+        textTheme: const TextTheme(
+          titleLarge: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: AppColors.darkTextMain,
+          ),
+          bodyLarge: TextStyle(color: AppColors.darkTextMain),
+          bodyMedium: TextStyle(color: AppColors.darkTextMain),
+          bodySmall: TextStyle(color: AppColors.darkTextFaded),
+        ),
+        useMaterial3: true,
+      );
+}

--- a/lib/widgets/home_sections/calendar_section.dart
+++ b/lib/widgets/home_sections/calendar_section.dart
@@ -32,7 +32,9 @@ class CalendarSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
-      color: isDark ? Colors.grey[850] : Colors.blue[50],
+      color: isDark
+          ? Colors.grey[850]
+          : Theme.of(context).colorScheme.primary.withOpacity(0.1),
       padding: const EdgeInsets.all(16),
       child: Card(
         elevation: 4,
@@ -47,16 +49,17 @@ class CalendarSection extends StatelessWidget {
             startingDayOfWeek: StartingDayOfWeek.monday,
             calendarStyle: CalendarStyle(
               outsideDaysVisible: false,
-              markerDecoration: const BoxDecoration(
-                color: Colors.orange,
+              markerDecoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.secondary,
                 shape: BoxShape.circle,
               ),
               selectedDecoration: BoxDecoration(
-                color: Colors.blue[600],
+                color: Theme.of(context).colorScheme.primary,
                 shape: BoxShape.circle,
               ),
               todayDecoration: BoxDecoration(
-                color: Colors.blue[300],
+                color:
+                    Theme.of(context).colorScheme.primary.withOpacity(0.7),
                 shape: BoxShape.circle,
               ),
             ),
@@ -65,7 +68,7 @@ class CalendarSection extends StatelessWidget {
               titleCentered: true,
               formatButtonShowsNext: false,
               formatButtonDecoration: BoxDecoration(
-                color: Colors.blue[600],
+                color: Theme.of(context).colorScheme.primary,
                 borderRadius: BorderRadius.circular(20),
               ),
               formatButtonTextStyle: const TextStyle(color: Colors.white),

--- a/lib/widgets/home_sections/muscle_recovery_section.dart
+++ b/lib/widgets/home_sections/muscle_recovery_section.dart
@@ -47,35 +47,28 @@ class MuscleRecoverySection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
 
-      final isDark = Theme.of(context).brightness == Brightness.dark;
-      final recoveryStatus = _getMuscleRecoveryStatus(context);
-      return Container(
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final recoveryStatus = _getMuscleRecoveryStatus(context);
+    return Container(
       color: isDark ? Colors.grey[900] : Colors.grey[100],
 
       padding: const EdgeInsets.all(16),
       child: Column(
         children: [
           Row(
-
             children: [
-              Icon(Icons.healing, color: isDark ? Colors.white : Colors.black),
+              Icon(Icons.healing,
+                  color: Theme.of(context).textTheme.titleLarge?.color),
               const SizedBox(width: 8),
-
               Text(
                 '근육 회복 상태',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-
-                  color: isDark ? Colors.white : Colors.black,
-
-                ),
+                style: Theme.of(context).textTheme.titleLarge,
               ),
             ],
           ),
           const SizedBox(height: 16),
 
-          _buildMuscleRecoveryView(recoveryStatus, isDark),
+          _buildMuscleRecoveryView(context, recoveryStatus, isDark),
 
         ],
       ),
@@ -83,8 +76,9 @@ class MuscleRecoverySection extends StatelessWidget {
   }
 
   Widget _buildMuscleRecoveryView(
-
-      Map<MuscleGroup, MuscleRecoveryInfo> recoveryStatus, bool isDark) {
+      BuildContext context,
+      Map<MuscleGroup, MuscleRecoveryInfo> recoveryStatus,
+      bool isDark) {
 
     return SizedBox(
       height: 400,
@@ -106,23 +100,18 @@ class MuscleRecoverySection extends StatelessWidget {
                 children: [
 
                   Text(
-
                     '회복 상태',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-
-                      color: isDark ? Colors.white : Colors.black,
-
-                    ),
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.bold),
                   ),
                   const SizedBox(height: 16),
                   Expanded(
                     child: ListView(
                       children: MuscleGroup.values
                           .map((muscle) => _buildMuscleInfoCard(
-
-                              recoveryStatus[muscle]!, isDark))
+                              context, recoveryStatus[muscle]!, isDark))
 
                           .toList(),
                     ),
@@ -137,7 +126,8 @@ class MuscleRecoverySection extends StatelessWidget {
   }
 
 
-  Widget _buildMuscleInfoCard(MuscleRecoveryInfo info, bool isDark) {
+  Widget _buildMuscleInfoCard(
+      BuildContext context, MuscleRecoveryInfo info, bool isDark) {
 
     Color statusColor = _getRecoveryColor(info.damageLevel);
     String statusText = _getRecoveryText(info.damageLevel);
@@ -145,7 +135,6 @@ class MuscleRecoverySection extends StatelessWidget {
 
     return Card(
       margin: const EdgeInsets.only(bottom: 8),
-
       color: isDark ? Colors.grey[800] : Colors.white,
 
       child: Padding(
@@ -158,12 +147,10 @@ class MuscleRecoverySection extends StatelessWidget {
               children: [
                 Text(
                   _getMuscleGroupName(info.muscleGroup),
-
-                  style: TextStyle(
-                    color: isDark ? Colors.white : Colors.black,
-
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyLarge
+                      ?.copyWith(fontWeight: FontWeight.bold),
                 ),
                 Container(
                   padding:
@@ -190,12 +177,7 @@ class MuscleRecoverySection extends StatelessWidget {
             const SizedBox(height: 4),
             Text(
               recoveryHours > 0 ? '회복까지 $recoveryHours시간' : '회복 완료',
-
-              style: TextStyle(
-                color: isDark ? Colors.grey[400] : Colors.grey[700],
-                fontSize: 12,
-              ),
-
+              style: Theme.of(context).textTheme.bodySmall,
             ),
           ],
         ),

--- a/lib/widgets/home_sections/scroll_hint_section.dart
+++ b/lib/widgets/home_sections/scroll_hint_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../theme/app_theme.dart';
 
 class ScrollHintSection extends StatelessWidget {
   const ScrollHintSection({super.key});
@@ -12,11 +13,11 @@ class ScrollHintSection extends StatelessWidget {
           Icon(
             Icons.keyboard_arrow_down,
             size: 30,
-            color: Colors.grey,
+            color: AppColors.hint,
           ),
           Text(
             '아래로 스크롤하여 운동 기록 보기',
-            style: TextStyle(color: Colors.grey, fontSize: 14),
+            style: TextStyle(color: AppColors.hint, fontSize: 14),
           ),
         ],
       ),

--- a/lib/widgets/home_sections/workout_log_section.dart
+++ b/lib/widgets/home_sections/workout_log_section.dart
@@ -26,16 +26,14 @@ class WorkoutLogSection extends StatelessWidget {
         children: [
           Row(
             children: [
-              Icon(Icons.fitness_center, color: Colors.blue[600]),
+              Icon(Icons.fitness_center,
+                  color: Theme.of(context).colorScheme.primary),
               const SizedBox(width: 8),
               Text(
                 selectedDay != null
                     ? '${selectedDay!.month}월 ${selectedDay!.day}일 운동 기록'
                     : '오늘의 운동 기록',
-                style: const TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                ),
+                style: Theme.of(context).textTheme.titleLarge,
               ),
             ],
           ),
@@ -61,13 +59,17 @@ class WorkoutLogSection extends StatelessWidget {
               const SizedBox(height: 16),
               Text(
                 '이 날의 운동 기록이 없습니다',
-                style: TextStyle(fontSize: 16, color: Colors.grey[600]),
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(fontSize: 16),
               ),
               const SizedBox(height: 8),
               ElevatedButton(
                 onPressed: onAddWorkout,
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.blue[600],
+                  backgroundColor:
+                      Theme.of(context).colorScheme.primary,
                 ),
                 child: const Text('운동 기록 추가'),
               ),
@@ -88,12 +90,17 @@ class WorkoutLogSection extends StatelessWidget {
           elevation: 2,
           child: ListTile(
             leading: CircleAvatar(
-              backgroundColor: Colors.blue[100],
-              child: Icon(Icons.fitness_center, color: Colors.blue[600]),
+              backgroundColor:
+                  Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              child: Icon(Icons.fitness_center,
+                  color: Theme.of(context).colorScheme.primary),
             ),
             title: Text(
               workout.exercise,
-              style: const TextStyle(fontWeight: FontWeight.bold),
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyLarge
+                  ?.copyWith(fontWeight: FontWeight.bold),
             ),
             subtitle: Text('${workout.sets} | ${workout.details}'),
             trailing: Row(

--- a/test/workout_test.dart
+++ b/test/workout_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutterstudy/main.dart';
 import 'package:flutterstudy/pages/workout_home_page.dart';
 import 'package:flutterstudy/models/workout.dart';


### PR DESCRIPTION
## Summary
- define primary and faded text colors in `AppColors`
- apply these colors via `AppTheme`
- use theme text colors in the muscle recovery and workout log sections
- fix missing `context` argument in `MuscleRecoverySection`

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be19de1ec8327be54b778ac10555c