### PR TITLE
Fix deprecated color usage

### DIFF
--- a/lib/widgets/home_sections/calendar_section.dart
+++ b/lib/widgets/home_sections/calendar_section.dart
@@ -34,7 +34,7 @@ class CalendarSection extends StatelessWidget {
     return Container(
       color: isDark
           ? Colors.grey[850]
-          : Theme.of(context).colorScheme.primary.withOpacity(0.1),
+          : Theme.of(context).colorScheme.primary.withAlpha(26),
       padding: const EdgeInsets.all(16),
       child: Card(
         elevation: 4,
@@ -59,7 +59,7 @@ class CalendarSection extends StatelessWidget {
               ),
               todayDecoration: BoxDecoration(
                 color:
-                    Theme.of(context).colorScheme.primary.withOpacity(0.7),
+                    Theme.of(context).colorScheme.primary.withAlpha(179),
                 shape: BoxShape.circle,
               ),
             ),

--- a/lib/widgets/home_sections/workout_log_section.dart
+++ b/lib/widgets/home_sections/workout_log_section.dart
@@ -91,7 +91,7 @@ class WorkoutLogSection extends StatelessWidget {
           child: ListTile(
             leading: CircleAvatar(
               backgroundColor:
-                  Theme.of(context).colorScheme.primary.withOpacity(0.2),
+                  Theme.of(context).colorScheme.primary.withAlpha(51),
               child: Icon(Icons.fitness_center,
                   color: Theme.of(context).colorScheme.primary),
             ),


### PR DESCRIPTION
## Summary
- replace deprecated `withOpacity` with `withAlpha`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bf172c120832790cc9deadf9b0ffd