### PR TITLE
Implement full-screen calendar navigation and new add workout page

### DIFF
--- a/lib/pages/add_workout_page.dart
+++ b/lib/pages/add_workout_page.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/exercise_presets.dart';
+import '../providers/workout_data.dart';
+import '../models/workout.dart';
+
+class AddWorkoutPage extends StatefulWidget {
+  final DateTime selectedDate;
+  const AddWorkoutPage({Key? key, required this.selectedDate}) : super(key: key);
+
+  @override
+  State<AddWorkoutPage> createState() => _AddWorkoutPageState();
+}
+
+class _AddWorkoutPageState extends State<AddWorkoutPage> {
+  final List<String> _queue = [];
+
+  @override
+  Widget build(BuildContext context) {
+    final presets = context.watch<ExercisePresets>().presets;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('운동 선택'),
+        actions: [
+          TextButton(
+            onPressed: _submit,
+            child: const Text('추가', style: TextStyle(color: Colors.white)),
+          )
+        ],
+      ),
+      body: Column(
+        children: [
+          SizedBox(
+            height: 80,
+            child: ReorderableListView(
+              scrollDirection: Axis.horizontal,
+              onReorder: (oldIndex, newIndex) {
+                setState(() {
+                  if (newIndex > oldIndex) newIndex -= 1;
+                  final item = _queue.removeAt(oldIndex);
+                  _queue.insert(newIndex, item);
+                });
+              },
+              children: [
+                for (final ex in _queue)
+                  Padding(
+                    key: ValueKey(ex),
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    child: Chip(
+                      label: Text(ex),
+                      onDeleted: () {
+                        setState(() {
+                          _queue.remove(ex);
+                        });
+                      },
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: GridView.builder(
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                childAspectRatio: 1.1,
+              ),
+              itemCount: presets.length,
+              itemBuilder: (context, index) {
+                final exercise = presets[index];
+                return GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _queue.add(exercise);
+                    });
+                  },
+                  child: Card(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(Icons.fitness_center, size: 32),
+                        const SizedBox(height: 8),
+                        Text(exercise, textAlign: TextAlign.center),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _submit() {
+    final provider = context.read<WorkoutData>();
+    for (final ex in _queue) {
+      final last = provider.latestRecordForExercise(ex);
+      if (last != null) {
+        provider.addWorkout(
+          widget.selectedDate,
+          WorkoutRecord(ex, last.sets, last.details, last.muscleGroup, last.intensity),
+        );
+      } else {
+        provider.addWorkout(
+          widget.selectedDate,
+          WorkoutRecord(ex, '', '', MuscleGroup.chest, 5),
+        );
+      }
+    }
+    Navigator.pop(context);
+  }
+}

--- a/lib/pages/workout_home_page.dart
+++ b/lib/pages/workout_home_page.dart
@@ -2,13 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 import '../models/workout.dart';
-import '../widgets/home_sections/muscle_recovery_section.dart';
 import '../widgets/home_sections/calendar_section.dart';
-import '../widgets/home_sections/scroll_hint_section.dart';
 import '../widgets/home_sections/workout_log_section.dart';
 import 'settings_page.dart';
 import '../providers/workout_data.dart';
-import '../providers/exercise_presets.dart';
+import 'add_workout_page.dart';
 import 'package:provider/provider.dart';
 
 class WorkoutHomePage extends StatefulWidget {
@@ -22,59 +20,13 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
   CalendarFormat _calendarFormat = CalendarFormat.month;
   DateTime _focusedDay = DateTime.now();
   DateTime? _selectedDay;
-  final ScrollController _scrollController = ScrollController();
-  final GlobalKey _recoveryKey = GlobalKey();
-  final GlobalKey _calendarKey = GlobalKey();
-  final GlobalKey _hintKey = GlobalKey();
-  final GlobalKey _logKey = GlobalKey();
-  List<double> _sectionOffsets = [];
-  bool _isSnapping = false;
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
 
   @override
   void initState() {
     super.initState();
     _selectedDay = DateTime.now();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _updateOffsets());
-  }
-
-  void _updateOffsets() {
-    _sectionOffsets = [];
-    double offset = 0;
-    final contexts = [
-      _recoveryKey.currentContext,
-      _calendarKey.currentContext,
-      _hintKey.currentContext,
-      _logKey.currentContext,
-    ];
-    for (final ctx in contexts) {
-      if (ctx == null) continue;
-      final box = ctx.findRenderObject() as RenderBox;
-      _sectionOffsets.add(offset);
-      offset += box.size.height;
-    }
-  }
-
-  void _snapScroll() {
-    if (_sectionOffsets.isEmpty || _isSnapping) return;
-    final current = _scrollController.offset;
-    double target = _sectionOffsets.first;
-    double diff = (current - target).abs();
-    for (final o in _sectionOffsets) {
-      final d = (current - o).abs();
-      if (d < diff) {
-        diff = d;
-        target = o;
-      }
-    }
-    if (diff < 1.0) return;
-    _isSnapping = true;
-    _scrollController
-        .animateTo(
-          target,
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.easeOut,
-        )
-        .then((_) => _isSnapping = false);
   }
 
   @override
@@ -104,197 +56,57 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
           ),
         ],
       ),
-      body: NotificationListener<ScrollEndNotification>(
-        onNotification: (notification) {
-          _updateOffsets();
-          _snapScroll();
-          return false;
-        },
-        child: CustomScrollView(
-          controller: _scrollController,
-          slivers: [
-            SliverToBoxAdapter(
-              child: MuscleRecoverySection(key: _recoveryKey),
-            ),
-            SliverToBoxAdapter(
-              child: CalendarSection(
-                key: _calendarKey,
-                calendarFormat: _calendarFormat,
-                focusedDay: _focusedDay,
-                selectedDay: _selectedDay,
-                onFormatChanged: (format) {
-                  setState(() => _calendarFormat = format);
-                },
-                onDaySelected: (selectedDay, focusedDay) {
-                  if (!isSameDay(_selectedDay, selectedDay)) {
-                    setState(() {
-                      _selectedDay = selectedDay;
-                      _focusedDay = focusedDay;
-                    });
-                  }
-                },
-                onPageChanged: (focusedDay) {
+      body: PageView(
+        controller: _pageController,
+        scrollDirection: Axis.vertical,
+        onPageChanged: (index) => setState(() => _currentPage = index),
+        children: [
+          CalendarSection(
+            calendarFormat: _calendarFormat,
+            focusedDay: _focusedDay,
+            selectedDay: _selectedDay,
+            onFormatChanged: (format) {
+              setState(() => _calendarFormat = format);
+            },
+            onDaySelected: (selectedDay, focusedDay) {
+              if (!isSameDay(_selectedDay, selectedDay)) {
+                setState(() {
+                  _selectedDay = selectedDay;
                   _focusedDay = focusedDay;
-                },
-              ),
-            ),
-            SliverToBoxAdapter(
-              child: ScrollHintSection(key: _hintKey),
-            ),
-            SliverToBoxAdapter(
-              child: WorkoutLogSection(
-                key: _logKey,
-                selectedDay: _selectedDay,
-                onAddWorkout: _showAddWorkoutDialog,
-                onDeleteWorkout: _deleteWorkout,
-              ),
-            ),
-          ],
-        ),
+                });
+              }
+            },
+            onPageChanged: (focusedDay) {
+              _focusedDay = focusedDay;
+            },
+          ),
+          WorkoutLogSection(
+            selectedDay: _selectedDay,
+            onAddWorkout: _openAddWorkoutPage,
+            onDeleteWorkout: _deleteWorkout,
+          ),
+        ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _showAddWorkoutDialog,
-        backgroundColor: Theme.of(context).colorScheme.primary,
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: _currentPage == 1
+          ? FloatingActionButton(
+              onPressed: _openAddWorkoutPage,
+              backgroundColor: Theme.of(context).colorScheme.primary,
+              child: const Icon(Icons.add),
+            )
+          : null,
     );
   }
 
-  void _showAddWorkoutDialog() {
-    final exerciseController = TextEditingController();
-    final setsController = TextEditingController();
-    final detailsController = TextEditingController();
-    MuscleGroup selectedMuscle = MuscleGroup.chest;
-    int selectedIntensity = 5;
-    final presetsProvider = Provider.of<ExercisePresets>(context, listen: false);
-
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return StatefulBuilder(
-          builder: (context, setDialogState) {
-            return AlertDialog(
-              title: const Text('운동 기록 추가'),
-              content: SingleChildScrollView(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Autocomplete<String>(
-                      optionsBuilder: (TextEditingValue textEditingValue) {
-                        if (textEditingValue.text == '') {
-                          return const Iterable<String>.empty();
-                        }
-                        return presetsProvider.presets.where((String option) {
-                          return option
-                              .toLowerCase()
-                              .contains(textEditingValue.text.toLowerCase());
-                        });
-                      },
-                      fieldViewBuilder: (context, textEditingController,
-                          focusNode, onFieldSubmitted) {
-                        exerciseController.text = textEditingController.text;
-                        return TextField(
-                          controller: textEditingController,
-                          focusNode: focusNode,
-                          decoration: const InputDecoration(
-                            labelText: '운동명',
-                            border: OutlineInputBorder(),
-                          ),
-                        );
-                      },
-                      onSelected: (selection) {
-                        exerciseController.text = selection;
-                      },
-                    ),
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: TextButton.icon(
-                        onPressed: () {
-                          if (exerciseController.text.isNotEmpty) {
-                            presetsProvider.addPreset(exerciseController.text);
-                          }
-                        },
-                        icon: const Icon(Icons.save),
-                        label: const Text('프리셋에 저장'),
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    TextField(
-                      controller: setsController,
-                      decoration: const InputDecoration(
-                        labelText: '세트 수',
-                        border: OutlineInputBorder(),
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    TextField(
-                      controller: detailsController,
-                      decoration: const InputDecoration(
-                        labelText: '상세 정보 (무게, 횟수 등)',
-                        border: OutlineInputBorder(),
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    DropdownButton<MuscleGroup>(
-                      value: selectedMuscle,
-                      isExpanded: true,
-                      items: MuscleGroup.values.map((muscle) {
-                        return DropdownMenuItem(
-                          value: muscle,
-                          child: Text(muscle.name),
-                        );
-                      }).toList(),
-                      onChanged: (value) {
-                        setDialogState(() {
-                          selectedMuscle = value!;
-                        });
-                      },
-                    ),
-                    const SizedBox(height: 16),
-                    Text('운동 강도: $selectedIntensity'),
-                    Slider(
-                      value: selectedIntensity.toDouble(),
-                      min: 1,
-                      max: 10,
-                      divisions: 9,
-                      onChanged: (value) {
-                        setDialogState(() {
-                          selectedIntensity = value.round();
-                        });
-                      },
-                    ),
-                  ],
-                ),
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: const Text('취소'),
-                ),
-                ElevatedButton(
-                  onPressed: () {
-                    if (exerciseController.text.isNotEmpty) {
-                      _addWorkout(
-                        exerciseController.text,
-                        setsController.text,
-                        detailsController.text,
-                        selectedMuscle,
-                        selectedIntensity,
-                      );
-                      Navigator.of(context).pop();
-                    }
-                  },
-
-                  style:
-                      ElevatedButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.primary),
-
-                  child: const Text('추가'),
-                ),
-              ],
-            );
-          },
-        );
-      },
+  void _openAddWorkoutPage() {
+    final selectedDate = DateTime(
+      _selectedDay!.year,
+      _selectedDay!.month,
+      _selectedDay!.day,
+    );
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => AddWorkoutPage(selectedDate: selectedDate),
+      ),
     );
   }
 
@@ -331,7 +143,6 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
 
   @override
   void dispose() {
-    _scrollController.dispose();
     super.dispose();
   }
 }

--- a/lib/providers/workout_data.dart
+++ b/lib/providers/workout_data.dart
@@ -51,6 +51,22 @@ class WorkoutData extends ChangeNotifier {
     _saveData();
   }
 
+  WorkoutRecord? latestRecordForExercise(String exercise) {
+    DateTime? latestDate;
+    WorkoutRecord? latest;
+    _workoutData.forEach((date, records) {
+      for (final r in records) {
+        if (r.exercise == exercise) {
+          if (latestDate == null || date.isAfter(latestDate!)) {
+            latestDate = date;
+            latest = r;
+          }
+        }
+      }
+    });
+    return latest;
+  }
+
   Future<void> _loadData() async {
     final prefs = await SharedPreferences.getInstance();
     final jsonString = prefs.getString(_storageKey);

--- a/lib/widgets/home_sections/calendar_section.dart
+++ b/lib/widgets/home_sections/calendar_section.dart
@@ -36,12 +36,7 @@ class CalendarSection extends StatelessWidget {
       color: isDark
           ? Colors.grey[850]
           : Theme.of(context).colorScheme.primary.withAlpha(26),
-      padding: const EdgeInsets.all(16),
-      child: Card(
-        elevation: 4,
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: TableCalendar<WorkoutRecord>(
+      child: TableCalendar<WorkoutRecord>(
             firstDay: DateTime.utc(2020, 1, 1),
             lastDay: DateTime.utc(2030, 12, 31),
             focusedDay: focusedDay,
@@ -85,8 +80,6 @@ class CalendarSection extends StatelessWidget {
             onFormatChanged: onFormatChanged,
             onPageChanged: onPageChanged,
           ),
-        ),
-      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- show the calendar and workout list as vertically swipable pages
- hide the add button until the workout page is visible
- remove calendar padding and make it fill the page
- add a new full-screen workout selection page
- support reordering selected exercises and using previous workout data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da5426050832794e571a1968cbd6e