### PR TITLE
Add draggable workout log sheet

### DIFF
--- a/lib/pages/workout_home_page.dart
+++ b/lib/pages/workout_home_page.dart
@@ -3,14 +3,12 @@ import 'package:table_calendar/table_calendar.dart';
 
 //import '../models/workout.dart';
 import '../widgets/home_sections/calendar_section.dart';
-import '../widgets/home_sections/workout_log_section.dart';
 import '../widgets/home_sections/muscle_recovery_section.dart';
 import 'settings_page.dart';
-import '../providers/workout_data.dart';
-import 'add_workout_page.dart';
-import 'workout_log_page.dart';
-import 'package:provider/provider.dart';
 
+import '../widgets/workout_log_sheet.dart';
+
+// 홈 화면 페이지로 달력과 운동 기록 시트를 포함한다
 class WorkoutHomePage extends StatefulWidget {
   const WorkoutHomePage({super.key});
 
@@ -18,11 +16,14 @@ class WorkoutHomePage extends StatefulWidget {
   WorkoutHomePageState createState() => WorkoutHomePageState();
 }
 
+// 홈 페이지의 상태 관리 클래스
 class WorkoutHomePageState extends State<WorkoutHomePage> {
   CalendarFormat _calendarFormat = CalendarFormat.month;
   DateTime _focusedDay = DateTime.now();
   DateTime? _selectedDay;
   late PageController _pageController;
+  // 운동 기록 시트 제어용 컨트롤러
+  late DraggableScrollableController _sheetController;
   int _currentPage = 1;
 
   @override
@@ -32,6 +33,7 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
     _pageController = PageController(
       initialPage: _currentPage,
     );
+    _sheetController = DraggableScrollableController();
   }
 
   @override
@@ -64,106 +66,54 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
       body: PageView(
         controller: _pageController,
         scrollDirection: Axis.vertical,
-        onPageChanged: (index) async {
+        onPageChanged: (index) {
           setState(() {
             _currentPage = index;
           });
-          if (index == 2) {
-            await Navigator.of(context).push(
-              PageRouteBuilder(
-                pageBuilder: (_, __, ___) =>
-                    WorkoutLogPage(selectedDay: _selectedDay),
-                transitionsBuilder: (_, animation, __, child) {
-                  return SlideTransition(
-                    position: Tween<Offset>(
-                      begin: const Offset(0, 1),
-                      end: Offset.zero,
-                    ).animate(animation),
-                    child: child,
-                  );
-                },
-              ),
-            );
-            _pageController.jumpToPage(1);
-          }
         },
         children: [
           const MuscleRecoverySection(),
-          Column(
+          Stack(
             children: [
-              Expanded(
-                child: GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onHorizontalDragEnd: _handleCalendarHorizontalDrag,
-                  child: CalendarSection(
-                    calendarFormat: _calendarFormat,
-                    focusedDay: _focusedDay,
-                    selectedDay: _selectedDay,
-                    onFormatChanged: (format) {
-                      setState(() => _calendarFormat = format);
-                    },
-                    onDaySelected: (selectedDay, focusedDay) {
-                      if (!isSameDay(_selectedDay, selectedDay)) {
-                        setState(() {
-                          _selectedDay = selectedDay;
-                          _focusedDay = focusedDay;
-                        });
-                      }
-                      _pageController.animateToPage(
-                        2,
-                        duration: const Duration(milliseconds: 300),
-                        curve: Curves.easeInOut,
-                      );
-                    },
-                    onPageChanged: (focusedDay) {
-                      _focusedDay = focusedDay;
-                    },
-                  ),
+              GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onHorizontalDragEnd: _handleCalendarHorizontalDrag,
+                child: CalendarSection(
+                  calendarFormat: _calendarFormat,
+                  focusedDay: _focusedDay,
+                  selectedDay: _selectedDay,
+                  onFormatChanged: (format) {
+                    setState(() => _calendarFormat = format);
+                  },
+                  onDaySelected: (selectedDay, focusedDay) {
+                    if (!isSameDay(_selectedDay, selectedDay)) {
+                      setState(() {
+                        _selectedDay = selectedDay;
+                        _focusedDay = focusedDay;
+                      });
+                    }
+                    _sheetController.animateTo(
+                      1.0,
+                      duration: const Duration(milliseconds: 300),
+                      curve: Curves.easeInOut,
+                    );
+                  },
+                  onPageChanged: (focusedDay) {
+                    _focusedDay = focusedDay;
+                  },
                 ),
               ),
-              ClipRect(
-                child: Align(
-                  alignment: Alignment.topCenter,
-                  heightFactor: 0.25,
-                  child: WorkoutLogSection(
-                    selectedDay: _selectedDay,
-                    onAddWorkout: _openAddWorkoutPage,
-                    onDeleteWorkout: _deleteWorkout,
-                  ),
-                ),
+              WorkoutLogSheet(
+                selectedDay: _selectedDay,
+                controller: _sheetController,
               ),
             ],
           ),
-          Container(),
         ],
       ),
     );
   }
-
-  void _openAddWorkoutPage() {
-    final selectedDate = DateTime(
-      _selectedDay!.year,
-      _selectedDay!.month,
-      _selectedDay!.day,
-    );
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => AddWorkoutPage(selectedDate: selectedDate),
-      ),
-    );
-  }
-
-  void _deleteWorkout(int index) {
-    final selectedDate = DateTime(
-      _selectedDay!.year,
-      _selectedDay!.month,
-      _selectedDay!.day,
-    );
-
-    final provider = Provider.of<WorkoutData>(context, listen: false);
-    provider.deleteWorkout(selectedDate, index);
-  }
-
+  // 달력을 좌우로 넘길 때 사용되는 드래그 핸들러
   void _handleCalendarHorizontalDrag(DragEndDetails details) {
     if (details.primaryVelocity == null) return;
     if (details.primaryVelocity! < 0) {
@@ -176,7 +126,6 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
       });
     }
   }
-
 
   @override
   void dispose() {

--- a/lib/pages/workout_log_page.dart
+++ b/lib/pages/workout_log_page.dart
@@ -1,10 +1,51 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+// 운동 기록 목록을 보여주는 섹션 위젯
 import '../widgets/home_sections/workout_log_section.dart';
+// 운동 데이터 제공자
 import '../providers/workout_data.dart';
+// 운동 추가 페이지
 import 'add_workout_page.dart';
 
+// 전체 화면이나 시트에서 재사용할 운동 기록 목록 본문 위젯
+class WorkoutLogBody extends StatefulWidget {
+  final DateTime? selectedDay;
+  final ScrollController? controller;
+  final VoidCallback onAddWorkout;
+  final void Function(int) onDeleteWorkout;
+
+  const WorkoutLogBody({
+    super.key,
+    required this.selectedDay,
+    this.controller,
+    required this.onAddWorkout,
+    required this.onDeleteWorkout,
+  });
+
+  @override
+  State<WorkoutLogBody> createState() => _WorkoutLogBodyState();
+}
+
+// WorkoutLogBody의 상태 클래스
+class _WorkoutLogBodyState extends State<WorkoutLogBody> {
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      controller: widget.controller,
+      children: [
+        WorkoutLogSection(
+          selectedDay: widget.selectedDay,
+          onAddWorkout: widget.onAddWorkout,
+          onDeleteWorkout: widget.onDeleteWorkout,
+        ),
+        const SizedBox(height: 80),
+      ],
+    );
+  }
+}
+
+// 전체 화면에서 사용하는 운동 기록 페이지
 class WorkoutLogPage extends StatefulWidget {
   final DateTime? selectedDay;
   const WorkoutLogPage({super.key, required this.selectedDay});
@@ -13,7 +54,9 @@ class WorkoutLogPage extends StatefulWidget {
   State<WorkoutLogPage> createState() => _WorkoutLogPageState();
 }
 
+// WorkoutLogPage의 상태 클래스
 class _WorkoutLogPageState extends State<WorkoutLogPage> {
+  // 운동 추가 페이지로 이동
   void _openAddWorkoutPage() {
     final selectedDate = DateTime(
       widget.selectedDay!.year,
@@ -27,6 +70,7 @@ class _WorkoutLogPageState extends State<WorkoutLogPage> {
     );
   }
 
+  // 운동 기록 삭제 처리
   void _deleteWorkout(int index) {
     final selectedDate = DateTime(
       widget.selectedDay!.year,
@@ -42,7 +86,7 @@ class _WorkoutLogPageState extends State<WorkoutLogPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('오늘의 운동')),
-      body: WorkoutLogSection(
+      body: WorkoutLogBody(
         selectedDay: widget.selectedDay,
         onAddWorkout: _openAddWorkoutPage,
         onDeleteWorkout: _deleteWorkout,

--- a/lib/widgets/workout_log_sheet.dart
+++ b/lib/widgets/workout_log_sheet.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+// 운동 기록 페이지를 드래그로 펼칠 수 있는 시트 위젯 파일
+import '../providers/workout_data.dart';
+import '../pages/add_workout_page.dart';
+import '../pages/workout_log_page.dart';
+// 홈 화면에서 사용되는 드래그 가능한 운동 기록 시트 위젯
+class WorkoutLogSheet extends StatefulWidget {
+  final DateTime? selectedDay;
+  final DraggableScrollableController controller;
+
+  const WorkoutLogSheet({
+    super.key,
+    required this.selectedDay,
+    required this.controller,
+  });
+
+  @override
+  State<WorkoutLogSheet> createState() => _WorkoutLogSheetState();
+}
+
+// 시트의 실제 동작을 담당하는 상태 클래스
+class _WorkoutLogSheetState extends State<WorkoutLogSheet> {
+  // 운동 추가 페이지로 이동
+  void _openAddWorkoutPage() {
+    final selectedDate = DateTime(
+      widget.selectedDay!.year,
+      widget.selectedDay!.month,
+      widget.selectedDay!.day,
+    );
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => AddWorkoutPage(selectedDate: selectedDate),
+      ),
+    );
+  }
+
+  // 운동 기록 삭제 처리
+  void _deleteWorkout(int index) {
+    final selectedDate = DateTime(
+      widget.selectedDay!.year,
+      widget.selectedDay!.month,
+      widget.selectedDay!.day,
+    );
+
+    final provider = Provider.of<WorkoutData>(context, listen: false);
+    provider.deleteWorkout(selectedDate, index);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      controller: widget.controller,
+      minChildSize: 0.25,
+      initialChildSize: 0.25,
+      maxChildSize: 1.0,
+      builder: (context, scrollController) {
+        return Container(
+          decoration: BoxDecoration(
+            color: Theme.of(context).scaffoldBackgroundColor,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+            boxShadow: const [BoxShadow(color: Colors.black26, blurRadius: 5)],
+          ),
+          child: Column(
+            children: [
+              GestureDetector(
+                onTap: () => widget.controller.animateTo(
+                  1.0,
+                  duration: const Duration(milliseconds: 300),
+                  curve: Curves.easeOut,
+                ),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Center(
+                    child: Container(
+                      width: 40,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: Colors.grey,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: WorkoutLogBody(
+                  selectedDay: widget.selectedDay,
+                  onAddWorkout: _openAddWorkoutPage,
+                  onDeleteWorkout: _deleteWorkout,
+                  controller: scrollController,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `WorkoutLogSheet` widget for draggable workout log
- refactor log page to expose reusable `WorkoutLogBody`
- embed draggable sheet in `WorkoutHomePage`
- add Korean comments for widgets and methods

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7ba39f588327a7de316b7dc13cfc