### PR TITLE
Enhance workout log sheet behavior

### DIFF
--- a/lib/widgets/home_sections/workout_log_section.dart
+++ b/lib/widgets/home_sections/workout_log_section.dart
@@ -154,45 +154,57 @@ class _WorkoutLogSectionState extends State<WorkoutLogSection> {
                     for (int i = 0; i < workout.setDetails.length; i++)
                       Padding(
                         padding: const EdgeInsets.only(bottom: 4),
-                        child: ChoiceChip(
-                          label: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              EditableNumber(
-                                value: workout.setDetails[i].weight,
-                                onChanged: (v) {
-                                  Provider.of<WorkoutData>(context, listen: false)
-                                      .updateSet(
-                                          widget.selectedDay ?? DateTime.now(),
-                                          index,
-                                          i,
-                                          weight: v.toDouble());
-                                },
-                              ),
-                              const Text('kg x '),
-                              EditableNumber(
-                                value: workout.setDetails[i].reps,
-                                integer: true,
-                                onChanged: (v) {
-                                  Provider.of<WorkoutData>(context, listen: false)
-                                      .updateSet(
-                                          widget.selectedDay ?? DateTime.now(),
-                                          index,
-                                          i,
-                                          reps: v.toInt());
-                                },
-                              ),
-                            ],
+                        child: SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: workout.setDetails[i].done
+                                  ? Theme.of(context).colorScheme.primary
+                                  : Theme.of(context).colorScheme.surfaceVariant,
+                              foregroundColor: workout.setDetails[i].done
+                                  ? Colors.white
+                                  : Theme.of(context).colorScheme.onSurface,
+                            ),
+                            onPressed: () {
+                              Provider.of<WorkoutData>(context, listen: false)
+                                  .toggleSetDone(
+                                      widget.selectedDay ?? DateTime.now(),
+                                      index,
+                                      i);
+                              _startRestTimer(context);
+                            },
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              mainAxisSize: MainAxisSize.max,
+                              children: [
+                                EditableNumber(
+                                  value: workout.setDetails[i].weight,
+                                  onChanged: (v) {
+                                    Provider.of<WorkoutData>(context,
+                                            listen: false)
+                                        .updateSet(
+                                            widget.selectedDay ??
+                                                DateTime.now(),
+                                            index,
+                                            i,
+                                            weight: v.toDouble());
+                                  },
+                                ),
+                                const Text('kg x '),
+                                EditableNumber(
+                                  value: workout.setDetails[i].reps,
+                                  integer: true,
+                                  onChanged: (v) {
+                                    Provider.of<WorkoutData>(context,
+                                            listen: false)
+                                        .updateSet(widget.selectedDay ??
+                                            DateTime.now(), index, i,
+                                            reps: v.toInt());
+                                  },
+                                ),
+                              ],
+                            ),
                           ),
-                          selected: workout.setDetails[i].done,
-                          onSelected: (_) {
-                            Provider.of<WorkoutData>(context, listen: false)
-                                .toggleSetDone(
-                                    widget.selectedDay ?? DateTime.now(),
-                                    index,
-                                    i);
-                            _startRestTimer(context);
-                          },
                         ),
                       ),
                   ],

--- a/lib/widgets/workout_log_sheet.dart
+++ b/lib/widgets/workout_log_sheet.dart
@@ -22,6 +22,32 @@ class WorkoutLogSheet extends StatefulWidget {
 
 // 시트의 실제 동작을 담당하는 상태 클래스
 class _WorkoutLogSheetState extends State<WorkoutLogSheet> {
+  bool _expanded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_handleDrag);
+  }
+
+  void _handleDrag() {
+    if (!_expanded && widget.controller.size > 0.3) {
+      _expanded = true;
+      widget.controller.animateTo(
+        1.0,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    } else if (_expanded && widget.controller.size <= 0.25) {
+      _expanded = false;
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_handleDrag);
+    super.dispose();
+  }
   // 운동 추가 페이지로 이동
   void _openAddWorkoutPage() {
     final selectedDate = DateTime(
@@ -52,7 +78,7 @@ class _WorkoutLogSheetState extends State<WorkoutLogSheet> {
   Widget build(BuildContext context) {
     return DraggableScrollableSheet(
       controller: widget.controller,
-      minChildSize: 0.25,
+      minChildSize: 0.2,
       initialChildSize: 0.25,
       maxChildSize: 1.0,
       builder: (context, scrollController) {


### PR DESCRIPTION
## Summary
- auto-expand workout log sheet when dragged slightly
- allow collapsing sheet further to show underlying sections
- redesign set completion buttons to occupy full width and keep editable weight & reps

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8117a3b48327a41ee5fc9284f9ef