### PR TITLE
Fix workout log display and rest timer behavior

### DIFF
--- a/lib/pages/workout_log_page.dart
+++ b/lib/pages/workout_log_page.dart
@@ -15,6 +15,7 @@ class WorkoutLogBody extends StatefulWidget {
   final VoidCallback onAddWorkout;
   final void Function(int) onDeleteWorkout;
   final bool showOnlyHeader;
+  final DraggableScrollableController? sheetController;
 
   const WorkoutLogBody({
     super.key,
@@ -23,6 +24,7 @@ class WorkoutLogBody extends StatefulWidget {
     required this.onAddWorkout,
     required this.onDeleteWorkout,
     this.showOnlyHeader = false,
+    this.sheetController,
   });
 
   @override
@@ -41,6 +43,7 @@ class _WorkoutLogBodyState extends State<WorkoutLogBody> {
           onAddWorkout: widget.onAddWorkout,
           onDeleteWorkout: widget.onDeleteWorkout,
           showOnlyHeader: widget.showOnlyHeader,
+          sheetController: widget.sheetController,
         ),
         if (!widget.showOnlyHeader) const SizedBox(height: 80),
       ],
@@ -93,6 +96,7 @@ class _WorkoutLogPageState extends State<WorkoutLogPage> {
         selectedDay: widget.selectedDay,
         onAddWorkout: _openAddWorkoutPage,
         onDeleteWorkout: _deleteWorkout,
+        sheetController: null,
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _openAddWorkoutPage,

--- a/lib/providers/workout_data.dart
+++ b/lib/providers/workout_data.dart
@@ -7,18 +7,23 @@ import '../models/workout.dart';
 class WorkoutData extends ChangeNotifier {
   static const String _storageKey = 'workoutData';
 
+  static DateTime _day(int offset) {
+    final now = DateTime.now().add(Duration(days: offset));
+    return DateTime(now.year, now.month, now.day);
+  }
+
   final Map<DateTime, List<WorkoutRecord>> _workoutData = {
-    DateTime.now(): [
+    _day(0): [
       WorkoutRecord('벤치프레스', '3세트', '80kg x 10회', MuscleGroup.chest, 8),
       WorkoutRecord('스쿼트', '4세트', '100kg x 8회', MuscleGroup.legs, 9),
       WorkoutRecord('데드리프트', '3세트', '120kg x 5회', MuscleGroup.back, 9),
     ],
-    DateTime.now().subtract(Duration(days: 1)): [
+    _day(-1): [
       WorkoutRecord('풀업', '3세트', '체중 x 12회', MuscleGroup.back, 7),
       WorkoutRecord('딥스', '3세트', '체중 x 15회', MuscleGroup.chest, 6),
       WorkoutRecord('어깨 프레스', '4세트', '40kg x 12회', MuscleGroup.shoulders, 8),
     ],
-    DateTime.now().subtract(Duration(days: 2)): [
+    _day(-2): [
       WorkoutRecord('바이셉 컬', '3세트', '15kg x 15회', MuscleGroup.arms, 6),
       WorkoutRecord('트라이셉 딥', '3세트', '체중 x 12회', MuscleGroup.arms, 7),
       WorkoutRecord('레그 프레스', '4세트', '150kg x 12회', MuscleGroup.legs, 8),
@@ -75,7 +80,8 @@ class WorkoutData extends ChangeNotifier {
     final Map<String, dynamic> jsonData = jsonDecode(jsonString);
     _workoutData.clear();
     jsonData.forEach((key, value) {
-      final date = DateTime.parse(key);
+      final parsed = DateTime.parse(key);
+      final date = DateTime(parsed.year, parsed.month, parsed.day);
       final List<dynamic> list = value as List<dynamic>;
       _workoutData[date] =
           list.map((e) => WorkoutRecord.fromJson(e as Map<String, dynamic>)).toList();

--- a/lib/widgets/home_sections/workout_log_section.dart
+++ b/lib/widgets/home_sections/workout_log_section.dart
@@ -11,6 +11,7 @@ class WorkoutLogSection extends StatefulWidget {
   final VoidCallback onAddWorkout;
   final void Function(int) onDeleteWorkout;
   final bool showOnlyHeader;
+  final DraggableScrollableController? sheetController;
 
   const WorkoutLogSection({
     super.key,
@@ -18,6 +19,7 @@ class WorkoutLogSection extends StatefulWidget {
     required this.onAddWorkout,
     required this.onDeleteWorkout,
     this.showOnlyHeader = false,
+    this.sheetController,
   });
 
   @override
@@ -94,8 +96,20 @@ class _WorkoutLogSectionState extends State<WorkoutLogSection> {
     return ListView.builder(
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
-      itemCount: workouts.length,
+      itemCount: workouts.length + 1,
       itemBuilder: (context, index) {
+        if (index == workouts.length) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: ElevatedButton(
+              onPressed: widget.onAddWorkout,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Theme.of(context).colorScheme.primary,
+              ),
+              child: const Text('운동 추가'),
+            ),
+          );
+        }
         final workout = workouts[index];
         return Card(
           margin: const EdgeInsets.only(bottom: 8),
@@ -267,6 +281,14 @@ class _WorkoutLogSectionState extends State<WorkoutLogSection> {
       ),
     );
     Overlay.of(context).insert(_restEntry!);
+    if (widget.sheetController != null &&
+        widget.sheetController!.size < 0.25) {
+      widget.sheetController!.animateTo(
+        0.25,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    }
   }
 }
 
@@ -308,16 +330,14 @@ class _RestTimerBarState extends State<RestTimerBar> {
   Widget build(BuildContext context) {
     final progress =
         1 - _secondsLeft / widget.duration.inSeconds.toDouble();
-    return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Material(
-          elevation: 4,
-          borderRadius: BorderRadius.circular(8),
-          color: Theme.of(context).colorScheme.primary,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Row(
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Material(
+        elevation: 4,
+        color: Theme.of(context).colorScheme.primary,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
               children: [
                 Expanded(
                   child: LinearProgressIndicator(
@@ -332,7 +352,6 @@ class _RestTimerBarState extends State<RestTimerBar> {
                   style: const TextStyle(color: Colors.white),
                 ),
               ],
-            ),
           ),
         ),
       ),

--- a/lib/widgets/workout_log_sheet.dart
+++ b/lib/widgets/workout_log_sheet.dart
@@ -117,6 +117,7 @@ class _WorkoutLogSheetState extends State<WorkoutLogSheet> {
                   onDeleteWorkout: _deleteWorkout,
                   controller: scrollController,
                   showOnlyHeader: !_expanded,
+                  sheetController: widget.controller,
                 ),
               ),
             ],


### PR DESCRIPTION
## Summary
- allow adding workouts from workout log list
- keep rest timer flush with bottom of screen and prevent sheet from collapsing completely while timer is active
- normalize stored workout dates so logs appear when selecting other days

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb6fa86c0832785cf3464be8aa1c6