### PR TITLE
Fix workout log date change scroll bug

### DIFF
--- a/lib/pages/workout_log_page.dart
+++ b/lib/pages/workout_log_page.dart
@@ -36,6 +36,17 @@ class WorkoutLogBody extends StatefulWidget {
 // WorkoutLogBody의 상태 클래스
 class _WorkoutLogBodyState extends State<WorkoutLogBody> {
   @override
+  void didUpdateWidget(covariant WorkoutLogBody oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!isSameDay(oldWidget.selectedDay, widget.selectedDay)) {
+      final controller = widget.controller;
+      if (controller != null && controller.hasClients) {
+        controller.jumpTo(controller.position.minScrollExtent);
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ListView(
       controller: widget.controller,


### PR DESCRIPTION
## Summary
- reset list scroll position when the selected workout date changes to avoid blank content

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec5dbac6c83278d9282586818f3ed