### PR TITLE
Add intensity levels and improve set editing

### DIFF
--- a/lib/models/workout.dart
+++ b/lib/models/workout.dart
@@ -1,5 +1,42 @@
 enum MuscleGroup { chest, back, shoulders, arms, legs, core }
 
+enum IntensityLevel { warmup, low, medium, high }
+
+extension IntensityLevelExtension on IntensityLevel {
+  String get label {
+    switch (this) {
+      case IntensityLevel.warmup:
+        return '워밍업';
+      case IntensityLevel.low:
+        return '저강도';
+      case IntensityLevel.medium:
+        return '중강도';
+      case IntensityLevel.high:
+        return '고강도';
+    }
+  }
+
+  static IntensityLevel fromLabel(String label) {
+    return IntensityLevel.values.firstWhere(
+      (e) => e.label == label,
+      orElse: () => IntensityLevel.medium,
+    );
+  }
+
+  double get value {
+    switch (this) {
+      case IntensityLevel.warmup:
+        return 1;
+      case IntensityLevel.low:
+        return 2;
+      case IntensityLevel.medium:
+        return 3;
+      case IntensityLevel.high:
+        return 4;
+    }
+  }
+}
+
 extension MuscleGroupExtension on MuscleGroup {
   String get name => toString().split('.').last;
 
@@ -14,7 +51,7 @@ class WorkoutRecord {
   final String sets;
   final String details;
   final MuscleGroup muscleGroup;
-  final int intensity; // 1-10 scale
+  IntensityLevel intensity;
   final List<SetEntry> setDetails;
 
   WorkoutRecord(
@@ -22,8 +59,8 @@ class WorkoutRecord {
     this.sets,
     this.details,
     this.muscleGroup,
-    this.intensity,
-    [List<SetEntry>? setDetails]
+    [this.intensity = IntensityLevel.medium,
+    List<SetEntry>? setDetails]
   ) : setDetails = setDetails ?? [];
 
   Map<String, dynamic> toJson() => {
@@ -31,7 +68,7 @@ class WorkoutRecord {
         'sets': sets,
         'details': details,
         'muscleGroup': muscleGroup.name,
-        'intensity': intensity,
+        'intensity': intensity.name,
         'setDetails': setDetails.map((e) => e.toJson()).toList(),
       };
 
@@ -41,7 +78,10 @@ class WorkoutRecord {
       json['sets'] as String,
       json['details'] as String,
       MuscleGroupExtension.fromName(json['muscleGroup'] as String),
-      json['intensity'] as int,
+      IntensityLevel.values.firstWhere(
+        (e) => e.name == json['intensity'],
+        orElse: () => IntensityLevel.medium,
+      ),
       (json['setDetails'] as List<dynamic>?)
               ?.map((e) => SetEntry.fromJson(e as Map<String, dynamic>))
               .toList() ??

--- a/lib/pages/add_workout_page.dart
+++ b/lib/pages/add_workout_page.dart
@@ -213,12 +213,18 @@ class _AddWorkoutPageState extends State<AddWorkoutPage> {
       if (last != null) {
         provider.addWorkout(
           widget.selectedDate,
-          WorkoutRecord(ex, last.sets, last.details, last.muscleGroup, last.intensity),
+          WorkoutRecord(
+            ex,
+            last.sets,
+            last.details,
+            last.muscleGroup,
+            last.intensity,
+          ),
         );
       } else {
         provider.addWorkout(
           widget.selectedDate,
-          WorkoutRecord(ex, '', '', MuscleGroup.chest, 5),
+          WorkoutRecord(ex, '', '', MuscleGroup.chest),
         );
       }
     }

--- a/lib/providers/workout_data.dart
+++ b/lib/providers/workout_data.dart
@@ -14,19 +14,28 @@ class WorkoutData extends ChangeNotifier {
 
   final Map<DateTime, List<WorkoutRecord>> _workoutData = {
     _day(0): [
-      WorkoutRecord('벤치프레스', '3세트', '80kg x 10회', MuscleGroup.chest, 8),
-      WorkoutRecord('스쿼트', '4세트', '100kg x 8회', MuscleGroup.legs, 9),
-      WorkoutRecord('데드리프트', '3세트', '120kg x 5회', MuscleGroup.back, 9),
+      WorkoutRecord('Bench Press', '3 sets', '80kg x 10', MuscleGroup.chest,
+          IntensityLevel.medium),
+      WorkoutRecord('Squat', '4 sets', '100kg x 8', MuscleGroup.legs,
+          IntensityLevel.high),
+      WorkoutRecord('Deadlift', '3 sets', '120kg x 5', MuscleGroup.back,
+          IntensityLevel.high),
     ],
     _day(-1): [
-      WorkoutRecord('풀업', '3세트', '체중 x 12회', MuscleGroup.back, 7),
-      WorkoutRecord('딥스', '3세트', '체중 x 15회', MuscleGroup.chest, 6),
-      WorkoutRecord('어깨 프레스', '4세트', '40kg x 12회', MuscleGroup.shoulders, 8),
+      WorkoutRecord('Pull Up', '3 sets', 'Bodyweight x 12', MuscleGroup.back,
+          IntensityLevel.low),
+      WorkoutRecord('Dip', '3 sets', 'Bodyweight x 15', MuscleGroup.chest,
+          IntensityLevel.low),
+      WorkoutRecord('Shoulder Press', '4 sets', '40kg x 12',
+          MuscleGroup.shoulders, IntensityLevel.medium),
     ],
     _day(-2): [
-      WorkoutRecord('바이셉 컬', '3세트', '15kg x 15회', MuscleGroup.arms, 6),
-      WorkoutRecord('트라이셉 딥', '3세트', '체중 x 12회', MuscleGroup.arms, 7),
-      WorkoutRecord('레그 프레스', '4세트', '150kg x 12회', MuscleGroup.legs, 8),
+      WorkoutRecord('Bicep Curl', '3 sets', '15kg x 15', MuscleGroup.arms,
+          IntensityLevel.low),
+      WorkoutRecord('Tricep Dip', '3 sets', 'Bodyweight x 12', MuscleGroup.arms,
+          IntensityLevel.low),
+      WorkoutRecord('Leg Press', '4 sets', '150kg x 12', MuscleGroup.legs,
+          IntensityLevel.medium),
     ],
   };
 
@@ -98,11 +107,23 @@ class WorkoutData extends ChangeNotifier {
     await prefs.setString(_storageKey, jsonEncode(jsonData));
   }
 
-  void addSet(DateTime day, int workoutIndex, SetEntry set) {
+  void addSet(DateTime day, int workoutIndex) {
     final key = DateTime(day.year, day.month, day.day);
     final workout = _workoutData[key]?[workoutIndex];
     if (workout != null) {
-      workout.setDetails.add(set);
+      double weight = 0;
+      int reps = 0;
+      if (workout.setDetails.isNotEmpty) {
+        weight = workout.setDetails.last.weight;
+        reps = workout.setDetails.last.reps;
+      } else {
+        final latest = latestRecordForExercise(workout.exercise);
+        if (latest != null && latest.setDetails.isNotEmpty) {
+          weight = latest.setDetails.last.weight;
+          reps = latest.setDetails.last.reps;
+        }
+      }
+      workout.setDetails.add(SetEntry(weight, reps));
       notifyListeners();
       _saveData();
     }
@@ -144,6 +165,17 @@ class WorkoutData extends ChangeNotifier {
         reps ?? current.reps,
         done: current.done,
       );
+      notifyListeners();
+      _saveData();
+    }
+  }
+
+  void updateIntensity(
+      DateTime day, int workoutIndex, IntensityLevel intensity) {
+    final key = DateTime(day.year, day.month, day.day);
+    final workout = _workoutData[key]?[workoutIndex];
+    if (workout != null) {
+      workout.intensity = intensity;
       notifyListeners();
       _saveData();
     }

--- a/lib/widgets/home_sections/muscle_recovery_section.dart
+++ b/lib/widgets/home_sections/muscle_recovery_section.dart
@@ -37,7 +37,7 @@ class _MuscleRecoverySectionState extends State<MuscleRecoverySection> {
         MuscleRecoveryInfo current = recoveryStatus[workout.muscleGroup]!;
 
         double timeFactor = 1.0 - (i * 0.3);
-        double damage = workout.intensity * timeFactor;
+        double damage = workout.intensity.value * timeFactor;
 
         if (damage > current.damageLevel) {
           recoveryStatus[workout.muscleGroup] = MuscleRecoveryInfo(

--- a/test/workout_test.dart
+++ b/test/workout_test.dart
@@ -14,8 +14,13 @@ void main() {
   test('addWorkout stores a workout record', () async {
     final data = WorkoutData();
     final date = DateTime(2024, 1, 1);
-    final record =
-        WorkoutRecord('Bench Test', '3set', '80kg x 10', MuscleGroup.chest, 8);
+    final record = WorkoutRecord(
+      'Bench Test',
+      '3 sets',
+      '80kg x 10',
+      MuscleGroup.chest,
+      IntensityLevel.medium,
+    );
 
     data.addWorkout(date, record);
 
@@ -27,8 +32,13 @@ void main() {
   test('deleteWorkout removes the workout record', () async {
     final data = WorkoutData();
     final date = DateTime(2024, 1, 1);
-    final record =
-        WorkoutRecord('Delete Test', '3set', '100kg x 5', MuscleGroup.back, 7);
+    final record = WorkoutRecord(
+      'Delete Test',
+      '3 sets',
+      '100kg x 5',
+      MuscleGroup.back,
+      IntensityLevel.low,
+    );
 
     data.addWorkout(date, record);
     expect(data.workoutsForDay(date).isNotEmpty, true);


### PR DESCRIPTION
## Summary
- unify default workout names and sets with exercise presets
- add `IntensityLevel` enum with labels and numeric value
- adjust models and providers to use new intensity type
- store default weight/reps when adding a set
- enable intensity editing via picker on workout log
- replace set editing fields with expandable +/- controls
- update muscle recovery logic
- update tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe8f4a48883278fa1fefda8c24ce6