### PR TITLE
Add max volume summary

### DIFF
--- a/lib/models/workout.dart
+++ b/lib/models/workout.dart
@@ -63,6 +63,22 @@ class WorkoutRecord {
     List<SetEntry>? setDetails]
   ) : setDetails = setDetails ?? [];
 
+  /// Returns the [SetEntry] with the largest training volume
+  /// (weight x reps) or `null` if there are no recorded sets.
+  SetEntry? get maxVolumeSet {
+    if (setDetails.isEmpty) return null;
+    return setDetails.reduce((a, b) =>
+        (a.weight * a.reps) >= (b.weight * b.reps) ? a : b);
+  }
+
+  /// Formatted text describing the highest volume set.
+  /// Returns an empty string when no sets exist.
+  String get maxVolumeSummary {
+    final best = maxVolumeSet;
+    if (best == null) return '';
+    return '${best.weight.toStringAsFixed(1)}kg x ${best.reps}';
+  }
+
   Map<String, dynamic> toJson() => {
         'exercise': exercise,
         'sets': sets,

--- a/lib/pages/workout_log_page.dart
+++ b/lib/pages/workout_log_page.dart
@@ -239,7 +239,7 @@ class _WorkoutLogSectionState extends State<WorkoutLogSection> {
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  subtitle: Text('${workout.sets} | ${workout.details}'),
+                  subtitle: Text(workout.maxVolumeSummary),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [

--- a/lib/providers/workout_data.dart
+++ b/lib/providers/workout_data.dart
@@ -12,32 +12,7 @@ class WorkoutData extends ChangeNotifier {
     return DateTime(now.year, now.month, now.day);
   }
 
-  final Map<DateTime, List<WorkoutRecord>> _workoutData = {
-    _day(0): [
-      WorkoutRecord('Bench Press', '3 sets', '80kg x 10', MuscleGroup.chest,
-          IntensityLevel.medium),
-      WorkoutRecord('Squat', '4 sets', '100kg x 8', MuscleGroup.legs,
-          IntensityLevel.high),
-      WorkoutRecord('Deadlift', '3 sets', '120kg x 5', MuscleGroup.back,
-          IntensityLevel.high),
-    ],
-    _day(-1): [
-      WorkoutRecord('Pull Up', '3 sets', 'Bodyweight x 12', MuscleGroup.back,
-          IntensityLevel.low),
-      WorkoutRecord('Dip', '3 sets', 'Bodyweight x 15', MuscleGroup.chest,
-          IntensityLevel.low),
-      WorkoutRecord('Shoulder Press', '4 sets', '40kg x 12',
-          MuscleGroup.shoulders, IntensityLevel.medium),
-    ],
-    _day(-2): [
-      WorkoutRecord('Bicep Curl', '3 sets', '15kg x 15', MuscleGroup.arms,
-          IntensityLevel.low),
-      WorkoutRecord('Tricep Dip', '3 sets', 'Bodyweight x 12', MuscleGroup.arms,
-          IntensityLevel.low),
-      WorkoutRecord('Leg Press', '4 sets', '150kg x 12', MuscleGroup.legs,
-          IntensityLevel.medium),
-    ],
-  };
+  final Map<DateTime, List<WorkoutRecord>> _workoutData = {};
 
   WorkoutData() {
     _loadData();


### PR DESCRIPTION
## Summary
- compute the set with the highest training volume
- display the best volume set in workout logs
- remove hard‑coded workout data

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850fe6aed088327b3b3edb85550b987