### PR TITLE
Fix Dart lint warnings

### DIFF
--- a/lib/pages/workout_log_page.dart
+++ b/lib/pages/workout_log_page.dart
@@ -551,7 +551,7 @@ class _SetRowState extends State<_SetRow> {
         Material(
           color: set.done
               ? Theme.of(context).colorScheme.primary
-              : Theme.of(context).colorScheme.surfaceVariant,
+              : Theme.of(context).colorScheme.surfaceContainerHighest,
           child: InkWell(
             onTap: () {
               provider.toggleSetDone(
@@ -575,7 +575,7 @@ class _SetRowState extends State<_SetRow> {
         ),
         if (_expanded)
           Container(
-            color: Theme.of(context).colorScheme.surfaceVariant,
+            color: Theme.of(context).colorScheme.surfaceContainerHighest,
             padding: const EdgeInsets.symmetric(vertical: 0),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/providers/workout_data.dart
+++ b/lib/providers/workout_data.dart
@@ -7,11 +7,6 @@ import '../models/workout.dart';
 class WorkoutData extends ChangeNotifier {
   static const String _storageKey = 'workoutData';
 
-  static DateTime _day(int offset) {
-    final now = DateTime.now().add(Duration(days: offset));
-    return DateTime(now.year, now.month, now.day);
-  }
-
   final Map<DateTime, List<WorkoutRecord>> _workoutData = {};
 
   WorkoutData() {

--- a/lib/widgets/home_sections/favorite_progress_section.dart
+++ b/lib/widgets/home_sections/favorite_progress_section.dart
@@ -86,7 +86,7 @@ class _FavoriteProgressSectionState extends State<FavoriteProgressSection> {
                         notification.metrics.maxScrollExtent &&
                     notification is OverscrollNotification &&
                     notification.overscroll > 0) {
-                  onScrollDown?.call();
+                  widget.onScrollDown?.call();
                 }
                 return false;
               },

--- a/lib/widgets/simple_line_chart.dart
+++ b/lib/widgets/simple_line_chart.dart
@@ -32,9 +32,8 @@ class _LineChartPainter extends CustomPainter {
   final double minY;
   final double maxY;
 
-  _LineChartPainter(List<double> values, double? minY, double? maxY)
-      : values = values,
-        minY = minY ?? (values.isEmpty ? 0 : values.reduce(min)),
+  _LineChartPainter(this.values, double? minY, double? maxY)
+      : minY = minY ?? (values.isEmpty ? 0 : values.reduce(min)),
         maxY = maxY ?? (values.isEmpty ? 0 : values.reduce(max));
 
   @override


### PR DESCRIPTION
## Summary
- remove unused `_day` helper
- use `widget.onScrollDown` in favorite progress section
- update deprecated color scheme API
- use initializing formal in line chart painter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685139b3097c83279f428dfe95083506