### PR TITLE
Fix viewport crash in home page

### DIFF
--- a/lib/pages/workout_home_page.dart
+++ b/lib/pages/workout_home_page.dart
@@ -76,7 +76,6 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
               ],
             ),
             SliverFillRemaining(
-              hasScrollBody: false,
               child: PageView(
                 controller: _pageController,
                 scrollDirection: Axis.vertical,


### PR DESCRIPTION
## Summary
- remove `hasScrollBody: false` from `SliverFillRemaining` to avoid intrinsic dimension exception

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685221c3a8d88327b01967584ff25130