### PR TITLE
Enable app bar hiding with log page scroll

### DIFF
--- a/lib/pages/workout_home_page.dart
+++ b/lib/pages/workout_home_page.dart
@@ -26,6 +26,7 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
   late DraggableScrollableController _sheetController;
   // 슬리버 앱바 제어용 스크롤 컨트롤러
   late ScrollController _scrollController;
+  double _logScrollOffset = 0;
   int _currentPage = 1;
 
   @override
@@ -121,6 +122,7 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
                       WorkoutLogSheet(
                         selectedDay: _selectedDay,
                         controller: _sheetController,
+                        onScroll: _handleLogScroll,
                       ),
                     ],
                   ),
@@ -148,10 +150,19 @@ class WorkoutHomePageState extends State<WorkoutHomePage> {
 
   // 드래그 시트 크기에 맞춰 앱바를 숨기기 위한 핸들러
   void _handleSheetDrag() {
+    _updateAppBarOffset();
+  }
+
+  void _handleLogScroll(double offset) {
+    _logScrollOffset = offset.clamp(0.0, kToolbarHeight);
+    _updateAppBarOffset();
+  }
+
+  void _updateAppBarOffset() {
     if (!_scrollController.hasClients) return;
-    final offset =
-        (_sheetController.size.clamp(0.0, 1.0)) * kToolbarHeight;
-    _scrollController.jumpTo(offset);
+    final baseOffset = (_sheetController.size.clamp(0.0, 1.0)) * kToolbarHeight;
+    final combined = (baseOffset + _logScrollOffset).clamp(0.0, kToolbarHeight);
+    _scrollController.jumpTo(combined);
   }
 
   void _goToCalendar() {

--- a/lib/pages/workout_log_page.dart
+++ b/lib/pages/workout_log_page.dart
@@ -23,6 +23,7 @@ class WorkoutLogBody extends StatefulWidget {
   final void Function(int) onDeleteWorkout;
   final bool showOnlyHeader;
   final DraggableScrollableController? sheetController;
+  final void Function(double)? onScroll;
 
   const WorkoutLogBody({
     super.key,
@@ -32,6 +33,7 @@ class WorkoutLogBody extends StatefulWidget {
     required this.onDeleteWorkout,
     this.showOnlyHeader = false,
     this.sheetController,
+    this.onScroll,
   });
 
   @override
@@ -41,14 +43,36 @@ class WorkoutLogBody extends StatefulWidget {
 // WorkoutLogBody의 상태 클래스
 class _WorkoutLogBodyState extends State<WorkoutLogBody> {
   @override
+  void initState() {
+    super.initState();
+    widget.controller?.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    if (widget.onScroll != null && widget.controller != null) {
+      widget.onScroll!(widget.controller!.offset);
+    }
+  }
+
+  @override
   void didUpdateWidget(covariant WorkoutLogBody oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller?.removeListener(_onScroll);
+      widget.controller?.addListener(_onScroll);
+    }
     if (!isSameDay(oldWidget.selectedDay, widget.selectedDay)) {
       final controller = widget.controller;
       if (controller != null && controller.hasClients) {
         controller.jumpTo(controller.position.minScrollExtent);
       }
     }
+  }
+
+  @override
+  void dispose() {
+    widget.controller?.removeListener(_onScroll);
+    super.dispose();
   }
 
   @override

--- a/lib/widgets/workout_log_sheet.dart
+++ b/lib/widgets/workout_log_sheet.dart
@@ -11,11 +11,13 @@ import '../utils/workout_log_utils.dart';
 class WorkoutLogSheet extends StatefulWidget {
   final DateTime? selectedDay;
   final DraggableScrollableController controller;
+  final void Function(double)? onScroll;
 
   const WorkoutLogSheet({
     super.key,
     required this.selectedDay,
     required this.controller,
+    this.onScroll,
   });
 
   @override
@@ -80,6 +82,7 @@ class _WorkoutLogSheetState extends State<WorkoutLogSheet> {
                   controller: scrollController,
                   showOnlyHeader: !_expanded,
                   sheetController: widget.controller,
+                  onScroll: widget.onScroll,
                 ),
               ),
             ],


### PR DESCRIPTION
## Summary
- expose scroll callback from `WorkoutLogBody`
- pipe scroll callback through `WorkoutLogSheet`
- connect sheet scroll updates to home page app bar

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685234c2c0f483279678cc47a352d628